### PR TITLE
Various modifications

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,12 @@
+steps:
+  - label: ":debian: Create Debian File"
+    command: "buildkite-scripts/scripts/fpm.sh"
+    env:
+      DEB_NAME: virtru-devops-shudder
+  
+  - wait
+
+  - label: ":debian: Upload Debian File"
+    command: "buildkite-scripts/scripts/deb-s3.sh"
+    env:
+      APT_REPO_NAME: shared

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,4 +10,4 @@ steps:
     command: "buildkite-scripts/scripts/deb-s3.sh"
     env:
       APT_REPO_NAME: shared
-      ENVIRONMENT_NAME: " "
+      ENVIRONMENT_NAME: "0"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,3 +10,4 @@ steps:
     command: "buildkite-scripts/scripts/deb-s3.sh"
     env:
       APT_REPO_NAME: shared
+      ENVIRONMENT_NAME: " "

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ give your autoscaling group a lifecycle hook that publishes to an SNS topic that
 you configure in shudder. When shudder starts up, it will create an SQS queue
 for the instance it is running on and subscribe it to the SNS topic. It polls
 for new messages and waits for one that is a termination command for this
-instance, and sends a GET request to a configured endpoint telling it to
-shut down gracefully.
+instance. It can then send a GET request to a configured endpoint telling it to
+shut down gracefully, or execute commands.
 
 It can also detect when a spot instance has been scheduled for termination, 
 using the [instance termination notice](https://aws.amazon.com/blogs/aws/new-ec2-spot-instance-termination-notices/) 
@@ -32,6 +32,7 @@ sqs_prefix = "myapp"
 region = "us-east-1"
 sns_topic = "arn:aws:sns:us-east-1:723456455537:myapp-shutdowns"
 endpoint = "http://127.0.0.1:5000/youaregoingtodiesoon"
+commands = [["//etc/init.d/nginx", "stop"], ["/etc/init.d/filebeats", "stop"]]
 ```
 
 You can specify the config file path as an environment variable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto==2.32.1
+boto3==1.4.4
 toml==0.8.2
 requests==2.4.3

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -18,10 +18,26 @@ import shudder.metadata as metadata
 from shudder.config import CONFIG
 
 import time
+import os
 import requests
+import signal
 import subprocess
+import sys
+
+def receive_signal(signum, stack):
+    if signum in [1,2,3,15,17]:
+        print 'Caught signal %s, exiting.' %(str(signum))
+        sys.exit()
+    else:
+        print 'Caught signal %s, ignoring.' %(str(signum))
 
 if __name__ == '__main__':
+    uncatchable = ['SIG_DFL','SIGSTOP','SIGKILL']
+    for i in [x for x in dir(signal) if x.startswith("SIG")]:
+        if not i in uncatchable:
+            signum = getattr(signal,i)
+            signal.signal(signum,receive_signal)
+
     sqs_connection, sqs_queue = queue.create_queue()
     sns_connection, subscription_arn = queue.subscribe_sns(sqs_queue)
     while True:

--- a/shudder/metadata.py
+++ b/shudder/metadata.py
@@ -22,3 +22,9 @@ def poll_instance_metadata():
     """Check instance metadata for a scheduled termination"""
     r = requests.get("http://169.254.169.254/latest/meta-data/spot/termination-time")
     return r.status_code < 400
+
+def get_instance_id():
+    """Check instance metadata for an instance id"""
+    r = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
+    return r.text
+

--- a/shudder/queue.py
+++ b/shudder/queue.py
@@ -18,54 +18,103 @@ impending doom.
 
 """
 import json
-
-from boto.utils import get_instance_metadata
-import boto.sns as sns
-import boto.sqs as sqs
+import boto3
+import hashlib
 
 from shudder.config import CONFIG
+import shudder.metadata as metadata
 
 
-INSTANCE_ID = get_instance_metadata()['instance-id']
+INSTANCE_ID = metadata.get_instance_id()
 QUEUE_NAME = "{prefix}-{id}".format(prefix=CONFIG['sqs_prefix'],
                                     id=INSTANCE_ID)
 
 
 def create_queue():
-    """Creates the SQS queue and returns the connection/queue"""
-    conn = sqs.connect_to_region(CONFIG['region'])
-    queue = conn.create_queue(QUEUE_NAME)
-    queue.set_timeout(60 * 60)  # one hour
+    """Creates the SQS queue and returns the queue url and metadata"""
+    conn = boto3.client('sqs', region_name=CONFIG['region'])
+    queue_metadata = conn.create_queue(QueueName=QUEUE_NAME, Attributes={'VisibilityTimeout':'3600'})
+    """Get the SQS queue object from the queue URL"""
+    sqs = boto3.resource('sqs', region_name=CONFIG['region'])
+    queue = sqs.Queue(queue_metadata['QueueUrl'])
     return conn, queue
 
 
 def subscribe_sns(queue):
+    """Attach a policy to allow incoming connections from SNS"""
+    statement_id = hashlib.md5((CONFIG['sns_topic'] +  queue.attributes.get('QueueArn')).encode('utf-8')).hexdigest()
+    statement_id_exists = False
+    existing_policy = queue.attributes.get('Policy')
+    if existing_policy: 
+        policy = json.loads(existing_policy)
+    else:
+        policy = {}
+    if 'Version' not in policy:
+        policy['Version'] = '2008-10-17'
+    if 'Statement' not in policy:
+        policy['Statement'] = []
+    # See if a Statement with the Sid exists already.
+    for statement in policy['Statement']:
+        if statement['Sid'] == statement_id:
+           statement_id_exists = True
+    if not statement_id_exists:
+        statement = {'Action': 'SQS:SendMessage',
+            'Effect': 'Allow',
+            'Principal': {'AWS': '*'},
+            'Resource': queue.attributes.get('QueueArn'),
+            'Sid': statement_id,
+            'Condition': {"ForAllValues:ArnEquals":{"aws:SourceArn":CONFIG['sns_topic']}}}
+        policy['Statement'].append(statement)
+    queue.set_attributes(Attributes={'Policy':json.dumps(policy)})
     """Subscribes the SNS topic to the queue."""
-    conn = sns.connect_to_region(CONFIG['region'])
-    sub = conn.subscribe_sqs_queue(CONFIG['sns_topic'], queue)
-    sns_arn = sub['SubscribeResponse']['SubscribeResult']['SubscriptionArn']
+    conn = boto3.client('sns', region_name=CONFIG['region'])
+    sub = conn.subscribe(TopicArn=CONFIG['sns_topic'], Protocol='sqs', Endpoint=queue.attributes.get('QueueArn'))
+    sns_arn = sub['SubscriptionArn']
     return conn, sns_arn
 
 
 def should_terminate(msg):
     """Check if the termination message is about our instance"""
-    first_box = json.loads(msg.get_body())
-    body = json.loads(first_box['Message'])
+    first_box = json.loads(msg.body)
+    message = json.loads(first_box['Message'])
     termination_msg = 'autoscaling:EC2_INSTANCE_TERMINATING'
-    return body.get('LifecycleTransition') == termination_msg \
-        and INSTANCE_ID == body['EC2InstanceId']
 
+    if message['LifecycleTransition'] == termination_msg and INSTANCE_ID == message['EC2InstanceId']:
+        return message
+    else:
+        return None
 
 def clean_up_sns(sns_conn, sns_arn, queue):
     """Clean up SNS subscription and SQS queue"""
     queue.delete()
-    sns_conn.unsubscribe(sns_arn)
+    sns_conn.unsubscribe(SubscriptionArn=sns_arn)
+
+
+def record_lifecycle_action_heartbeat(message):
+    """Let AWS know we're still in the process of shutting down"""
+    conn = boto3.client('autoscaling', region_name=CONFIG['region'])
+    conn.record_lifecycle_action_heartbeat(
+        LifecycleHookName=message['LifecycleHookName'],
+        AutoScalingGroupName=message['AutoScalingGroupName'],
+        LifecycleActionToken=message['LifecycleActionToken'],
+        InstanceId=message['EC2InstanceId'])
+
+
+def complete_lifecycle_action(message):
+    """Let AWS know it's safe to terminate the instance now"""
+    conn = boto3.client('autoscaling', region_name=CONFIG['region'])
+    conn.complete_lifecycle_action(
+        LifecycleHookName=message['LifecycleHookName'],
+        AutoScalingGroupName=message['AutoScalingGroupName'],
+        LifecycleActionToken=message['LifecycleActionToken'],
+        LifecycleActionResult='CONTINUE',
+        InstanceId=message['EC2InstanceId'])
 
 
 def poll_queue(conn, queue):
     """Poll SQS until we get a termination message."""
-    message = queue.read()
-    if message:
-        conn.delete_message(queue, message)
+    messages = queue.receive_messages()
+    for message in messages:
+        message.delete()
         return should_terminate(message)
     return False


### PR DESCRIPTION
I wanted to share various modifications we've made to shudder. I realize not all of this matters, and I'd be happy to clean up this PR if there's value in merging it in. For example it's quite clear your don't need our .buildkite folder.

Some helper functions that existed in boto2 don't exist in boto3, and thus those helper functions had to be ported in, and updated for boto3.

Summation of whats been done:

- Support executing commands on the box running shudder, not just notifying a URL
- Moving to boto3 so we can send lifecycle complete actions
- Sends lifecycle heartbeats when running commands

What could still be done:

- Testing spot instances, I may have broken things there
- Writing tests period
- Configuring what should happen if a URL fails (Change returning complete vs abandoned for logging purposes)
- Configuring what should happen if a command fails (Change returning complete vs abandoned for logging purposes)
- Sending lifecycle heart beats for urls
- Sending lifecycle complete for URLS
