### PR TITLE
Make it possible to call multiple endpoints on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You need a toml file looking like this:
 sqs_prefix = "myapp"
 region = "us-east-1"
 sns_topic = "arn:aws:sns:us-east-1:723456455537:myapp-shutdowns"
-endpoint = "http://127.0.0.1:5000/youaregoingtodiesoon"
+endpoints = ["http://127.0.0.1:5000/youaregoingtodiesoon", "http://127.0.0.1:5001/shutdown"]
 commands = [["//etc/init.d/nginx", "stop"], ["/etc/init.d/filebeats", "stop"]]
 ```
 

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -46,6 +46,9 @@ if __name__ == '__main__':
             queue.clean_up_sns(sns_connection, subscription_arn, sqs_queue)
             if 'endpoint' in CONFIG:
                 requests.get(CONFIG["endpoint"])
+            if 'endpoints' in CONFIG:
+                for endpoint in CONFIG["endpoints"]:
+                    requests.get(endpoint)
             if 'commands' in CONFIG:
                 for command in CONFIG["commands"]:
                     print 'Running command: %s' % command


### PR DESCRIPTION
The change is backward compatible. If you have an `endpoint` in your configuration it will still work.