### PR TITLE
Allow configurable tags on SQS queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,25 @@ region = "us-east-1"
 sns_topic = "arn:aws:sns:us-east-1:723456455537:myapp-shutdowns"
 endpoints = ["http://127.0.0.1:5000/youaregoingtodiesoon", "http://127.0.0.1:5001/shutdown"]
 commands = [["//etc/init.d/nginx", "stop"], ["/etc/init.d/filebeats", "stop"]]
+queue_tags = { tag1 = "value1", tag2 = "value2"}
 ```
+
+**sqs_prefix:** specifies the prefix of the sqs queue that will be created for the instance.
+Queues are named by concatenating the prefix to the instance id.
+
+**region:** specifies the AWS region
+
+**sns_topic:** specifies the arn of the SNS Topic that publishes lifecycle events for this
+instance's auto scaling group
+
+**endpoints:** specifies a list of http endpoints that shudder will execute a GET request on once
+shudder has received the shutdown lifecycle message
+
+**commands:** specifies a list of commands that shudder will execute once shudder has received the
+shutdown lifecycle message
+
+**queue_tags:** the aws resource tags to assign to the SQS queue that is created by Shudder for the
+instance its running on
 
 You can specify the config file path as an environment variable:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.4.4
-toml==0.8.2
+boto3==1.7.58
+toml==0.9.4
 requests==2.4.3

--- a/shudder/queue.py
+++ b/shudder/queue.py
@@ -34,6 +34,10 @@ def create_queue():
     """Creates the SQS queue and returns the queue url and metadata"""
     conn = boto3.client('sqs', region_name=CONFIG['region'])
     queue_metadata = conn.create_queue(QueueName=QUEUE_NAME, Attributes={'VisibilityTimeout':'3600'})
+
+    if 'queue_tags' in CONFIG:
+        conn.tag_queue(QueueUrl=queue_metadata['QueueUrl'], Tags=CONFIG['queue_tags'])
+
     """Get the SQS queue object from the queue URL"""
     sqs = boto3.resource('sqs', region_name=CONFIG['region'])
     queue = sqs.Queue(queue_metadata['QueueUrl'])


### PR DESCRIPTION
I have a requirement to tag all of the resources in our AWS account so I needed to add a small enhancement to allow configurable tags on the SQS queue that Shudder creates.

The toml version update is to get support inline lists and the boto update is to get support for tag_queue