### PR TITLE
Implement try except for the metadata methods, implement loging to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 shudder.toml
 *.iml
 .idea/
+.vscode/

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -16,7 +16,6 @@
 import shudder.queue as queue
 import shudder.metadata as metadata
 from shudder.config import CONFIG
-from shudder.config import LOG_FILE
 import time
 import os
 import requests
@@ -24,7 +23,9 @@ import signal
 import subprocess
 import sys
 import logging
-logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+from requests.exceptions import ConnectionError
+
+logging.basicConfig(filename=CONFIG['logfile'],format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
 
 
 def receive_signal(signum, stack):
@@ -66,6 +67,6 @@ if __name__ == '__main__':
             sys.exit(0)
         time.sleep(5)
       except ConnectionError:
-        logging.error('Connection issue')
+        logging.exception('Connection issue')
       except:
-        logging.error('Something went wrong')
+        logging.exception('Something went wrong')

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -16,13 +16,16 @@
 import shudder.queue as queue
 import shudder.metadata as metadata
 from shudder.config import CONFIG
-
+from shudder.config import LOG_FILE
 import time
 import os
 import requests
 import signal
 import subprocess
 import sys
+import logging
+logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+
 
 def receive_signal(signum, stack):
     if signum in [1,2,3,15]:
@@ -41,6 +44,7 @@ if __name__ == '__main__':
     sqs_connection, sqs_queue = queue.create_queue()
     sns_connection, subscription_arn = queue.subscribe_sns(sqs_queue)
     while True:
+      try:
         message = queue.poll_queue(sqs_connection, sqs_queue)
         if message or metadata.poll_instance_metadata():
             queue.clean_up_sns(sns_connection, subscription_arn, sqs_queue)
@@ -61,3 +65,7 @@ if __name__ == '__main__':
             queue.complete_lifecycle_action(message)
             sys.exit(0)
         time.sleep(5)
+      except ConnectionError:
+        logging.error('Connection issue')
+      except:
+        logging.error('Something went wrong')

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -15,7 +15,7 @@
 """Start polling of SQS and metadata."""
 import shudder.queue as queue
 import shudder.metadata as metadata
-from shudder.config import CONFIG
+from shudder.config import CONFIG, LOG_FILE
 import time
 import os
 import requests
@@ -25,15 +25,14 @@ import sys
 import logging
 from requests.exceptions import ConnectionError
 
-logging.basicConfig(filename=CONFIG['logfile'],format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
 
 
 def receive_signal(signum, stack):
     if signum in [1,2,3,15]:
         print 'Caught signal %s, exiting.' %(str(signum))
         sys.exit()
-    else:
-        print 'Caught signal %s, ignoring.' %(str(signum))
+    else:        print 'Caught signal %s, ignoring.' %(str(signum))
 
 if __name__ == '__main__':
     uncatchable = ['SIG_DFL','SIGSTOP','SIGKILL']

--- a/shudder/config.py
+++ b/shudder/config.py
@@ -19,6 +19,7 @@ import toml
 
 CONFIG_FILE = os.environ.get('CONFIG_FILE', "shudder.toml")
 CONFIG = {}
+LOG_FILE = "/var/log/shudder.log"
 
 
 with open(CONFIG_FILE, 'r') as f:

--- a/shudder/config.py
+++ b/shudder/config.py
@@ -19,8 +19,6 @@ import toml
 
 CONFIG_FILE = os.environ.get('CONFIG_FILE', "shudder.toml")
 CONFIG = {}
-LOG_FILE = "/var/log/shudder.log"
-
 
 with open(CONFIG_FILE, 'r') as f:
     CONFIG = toml.loads(f.read())

--- a/shudder/config.py
+++ b/shudder/config.py
@@ -22,3 +22,7 @@ CONFIG = {}
 
 with open(CONFIG_FILE, 'r') as f:
     CONFIG = toml.loads(f.read())
+    if 'logfile' in  CONFIG.values():
+      LOG_FILE = CONFIG['logfile']
+    else:
+      LOG_FILE = os.environ.get('LOG_FILE', '/var/log/shudder.log')

--- a/shudder/metadata.py
+++ b/shudder/metadata.py
@@ -16,15 +16,25 @@
 
 """
 import requests
+import logging
+from config import LOG_FILE
 
+logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+termination_time = "http://169.254.169.254/latest/meta-data/spot/termination-time"
+instance_id = "http://169.254.169.254/latest/meta-data/instance-id"
 
 def poll_instance_metadata():
     """Check instance metadata for a scheduled termination"""
-    r = requests.get("http://169.254.169.254/latest/meta-data/spot/termination-time")
-    return r.status_code < 400
+    try:
+      r = requests.get(termination_time)
+      return r.status_code < 400
+    except:
+      logging.error('Request to ' + termination_time + ' failed.')
 
 def get_instance_id():
     """Check instance metadata for an instance id"""
-    r = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
-    return r.text
-
+    try:
+      r = requests.get(instance_id)
+      return r.text
+    except:
+      logging.error('Request to ' + instance_id + ' failed.')

--- a/shudder/metadata.py
+++ b/shudder/metadata.py
@@ -17,10 +17,10 @@
 """
 import requests
 import logging
-from shudder.config import CONFIG
+from shudder.config import CONFIG, LOG_FILE
 
 
-logging.basicConfig(filename=CONFIG['logfile'],format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
 termination_time = "http://169.254.169.254/latest/meta-data/spot/termination-time"
 instance_id = "http://169.254.169.254/latest/meta-data/instance-id"
 

--- a/shudder/metadata.py
+++ b/shudder/metadata.py
@@ -17,9 +17,10 @@
 """
 import requests
 import logging
-from config import LOG_FILE
+from shudder.config import CONFIG
 
-logging.basicConfig(filename=LOG_FILE,format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
+
+logging.basicConfig(filename=CONFIG['logfile'],format='%(asctime)s %(levelname)s:%(message)s',level=logging.INFO)
 termination_time = "http://169.254.169.254/latest/meta-data/spot/termination-time"
 instance_id = "http://169.254.169.254/latest/meta-data/instance-id"
 
@@ -29,7 +30,7 @@ def poll_instance_metadata():
       r = requests.get(termination_time)
       return r.status_code < 400
     except:
-      logging.error('Request to ' + termination_time + ' failed.')
+      logging.exception('Request to ' + termination_time + ' failed.')
 
 def get_instance_id():
     """Check instance metadata for an instance id"""
@@ -37,4 +38,4 @@ def get_instance_id():
       r = requests.get(instance_id)
       return r.text
     except:
-      logging.error('Request to ' + instance_id + ' failed.')
+      logging.exception('Request to ' + instance_id + ' failed.')


### PR DESCRIPTION
Current implementation does not handle errors, which in our case were often.
Issue is that AWS GW is sometimes refusing requests on the 169.254.169.254. When that happens, shudder crashes with error:

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/shudder/__main__.py", line 16, in <module>
    import shudder.queue as queue
  File "/usr/local/lib/python2.7/dist-packages/shudder/queue.py", line 28, in <module>
    INSTANCE_ID = metadata.get_instance_id()
  File "/usr/local/lib/python2.7/dist-packages/shudder/metadata.py", line 28, in get_instance_id
    r = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 60, in get
    return request('get', url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 49, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 407, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', error(111, 'Connection refused'))


Here I implemented basic error handling, and am redirecting those spotted errors to logfile. This way main process is preserved.