### PR TITLE
prevent infinite loop on sys.exit

### DIFF
--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -62,7 +62,12 @@ if __name__ == '__main__':
                     while process.poll() is None:
                         time.sleep(30)
                         """Send a heart beat to aws"""
-                        queue.record_lifecycle_action_heartbeat(message)
+                        try:
+                          queue.record_lifecycle_action_heartbeat(message)
+                        except:
+                          logging.exception('Error sending hearbeat for')
+                          logging.info(message)
+                        
             """Send a complete lifecycle action"""
             queue.complete_lifecycle_action(message)
             running = False

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -43,7 +43,9 @@ if __name__ == '__main__':
 
     sqs_connection, sqs_queue = queue.create_queue()
     sns_connection, subscription_arn = queue.subscribe_sns(sqs_queue)
-    while True:
+
+    running = True
+    while running:
       try:
         message = queue.poll_queue(sqs_connection, sqs_queue)
         if message or metadata.poll_instance_metadata():
@@ -63,9 +65,11 @@ if __name__ == '__main__':
                         queue.record_lifecycle_action_heartbeat(message)
             """Send a complete lifecycle action"""
             queue.complete_lifecycle_action(message)
-            sys.exit(0)
+            running = False
         time.sleep(5)
       except ConnectionError:
         logging.exception('Connection issue')
       except:
         logging.exception('Something went wrong')
+    logging.info('Success')
+    sys.exit(0)


### PR DESCRIPTION
In python when you call sys.exit(0) inside of a try catch it doesn't actually exit, this causes shudder to get into an infinite loop and logs the exception loop of queue does not exists from aws.   This prevents users from easily being able to read logs on graceful shutdown.